### PR TITLE
Removed hard check on ai_service parameter

### DIFF
--- a/llama_cpp/llama.py
+++ b/llama_cpp/llama.py
@@ -975,8 +975,6 @@ class Llama:
         _ttft_start = time.time()
         _pid = os.getpid()
         _tpot_metrics = []
-        if not ai_service:
-            raise ValueError("ai_service must be provided")
         _labels = {
             "service": ai_service if ai_service is not None else "not-specified",
             "request_type": "chat/completions",


### PR DESCRIPTION
Removed a line that would raise an exception if the `ai_service` parameter was not included in the request body. Resorting to a soft check, which adds `not-specified` instead.