### PR TITLE
Added mechanism to monitor task queue and log metric to prometheus

### DIFF
--- a/llama_cpp/llama.py
+++ b/llama_cpp/llama.py
@@ -38,13 +38,13 @@ from .llama_tokenizer import BaseLlamaTokenizer, LlamaTokenizer
 import llama_cpp.llama_cpp as llama_cpp
 import llama_cpp.llama_chat_format as llama_chat_format
 
-from llama_cpp.llama_metrics import Metrics, MetricsExporter
+from llama_cpp.llama_metrics import RequestMetrics, MetricsExporter
 
 from llama_cpp._utils import (
     get_cpu_usage, 
     get_ram_usage, 
     get_gpu_info_by_pid,
-    get_gpu_general_info,
+    get_gpu_general_info
 )
 
 from llama_cpp.llama_speculative import LlamaDraftModel
@@ -938,7 +938,7 @@ class Llama:
             return output, total_tokens
         else:
             return output
-
+        
     def _create_completion(
         self,
         prompt: Union[str, List[int]],
@@ -972,7 +972,6 @@ class Llama:
     ]:
         assert self._ctx is not None
         assert suffix is None or suffix.__class__ is str
-
         # Variables required for metric collection
         _metrics_dict = {}
         _ttft_start = time.time()
@@ -1464,8 +1463,8 @@ class Llama:
             } 
 
             # Log metrics to Prometheus
-            _all_metrics = Metrics(**_metrics_dict)
-            self.metrics.log_metrics(_all_metrics, labels=_labels)
+            _all_metrics = RequestMetrics(**_metrics_dict)
+            self.metrics.log_request_metrics(_all_metrics, labels=_labels)
             
             return
 
@@ -1585,8 +1584,8 @@ class Llama:
         } 
 
         # Log metrics to Prometheus
-        _all_metrics = Metrics(**_metrics_dict)
-        self.metrics.log_metrics(_all_metrics, labels=_labels)
+        _all_metrics = RequestMetrics(**_metrics_dict)
+        self.metrics.log_request_metrics(_all_metrics, labels=_labels)
 
         yield {
             "id": completion_id,

--- a/llama_cpp/llama_metrics.py
+++ b/llama_cpp/llama_metrics.py
@@ -6,11 +6,13 @@ from prometheus_client import Gauge, Info, Histogram
 
 LABELS = ["request_type", "service"]
 
+
 @dataclass
-class Metrics:
+class RequestMetrics:
     """
-    A dataclass to store metrics for a request.
+    A dataclass to store metrics for a given request.
     """
+
     # System metrics
     system_info: Dict[str, Any]
     state_size: int
@@ -33,8 +35,18 @@ class Metrics:
     completion_eval_throughput: float
     end_to_end_latency: float
     prefill_tokens: int
-    generation_tokens: int  
+    generation_tokens: int
     kv_cache_usage_ratio: float
+
+
+@dataclass
+class QueueMetrics:
+    """
+    A dataclass to store metrics for the task queue.
+    """
+
+    running_tasks_count: int
+    running_tasks: dict
 
 
 class MetricsExporter:
@@ -42,6 +54,7 @@ class MetricsExporter:
     A custom Prometheus Metrics Explorer for the LLAMA C++ backend.
     Collects metrics per request sent to the backend.
     """
+
     def __init__(self):
         self.labels = LABELS
         # One-time metrics
@@ -50,9 +63,26 @@ class MetricsExporter:
             documentation="Histogram of load time in seconds",
             labelnames=self.labels,
             buckets=[
-                0.1, 0.25, 0.5, 0.75, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0,
-                8.0, 9.0, 10.0, 12.5, 15.0, 20.0, 25.0, 30.0
-            ]
+                0.1,
+                0.25,
+                0.5,
+                0.75,
+                1.0,
+                2.0,
+                3.0,
+                4.0,
+                5.0,
+                6.0,
+                7.0,
+                8.0,
+                9.0,
+                10.0,
+                12.5,
+                15.0,
+                20.0,
+                25.0,
+                30.0,
+            ],
         )
         # Request-level latencies
         self._histogram_sample_time = Histogram(
@@ -60,54 +90,151 @@ class MetricsExporter:
             documentation="Histogram of token sampling time in seconds",
             labelnames=self.labels,
             buckets=[
-                0.00001, 0.00005, 0.0001, 0.00025, 0.0005, 0.001, 0.0025,
-                0.005, 0.0075, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5,
-            ]
+                0.00001,
+                0.00005,
+                0.0001,
+                0.00025,
+                0.0005,
+                0.001,
+                0.0025,
+                0.005,
+                0.0075,
+                0.01,
+                0.025,
+                0.05,
+                0.075,
+                0.1,
+                0.25,
+                0.5,
+            ],
         )
         self._histogram_time_to_first_token = Histogram(
             name="llama_cpp_python:ttft_seconds",
             documentation="Histogram of time to first token in seconds",
             labelnames=self.labels,
             buckets=[
-                0.001, 0.005, 0.01, 0.02, 0.04, 0.06, 0.08, 0.1, 0.25, 0.5,
-                0.75, 1.0, 2.5, 5.0, 7.5, 10.0, 12.5, 15.0, 20.0, 25.0, 30.0
-            ]
+                0.001,
+                0.005,
+                0.01,
+                0.02,
+                0.04,
+                0.06,
+                0.08,
+                0.1,
+                0.25,
+                0.5,
+                0.75,
+                1.0,
+                2.5,
+                5.0,
+                7.5,
+                10.0,
+                12.5,
+                15.0,
+                20.0,
+                25.0,
+                30.0,
+            ],
         )
         self._histogram_time_per_output_token = Histogram(
             name="llama_cpp_python:tpot_seconds",
             documentation="Histogram of time per output token in seconds",
             labelnames=self.labels,
             buckets=[
-                0.001, 0.005, 0.01, 0.02, 0.04, 0.06, 0.08, 0.1, 0.25, 0.5,
-                0.75, 1.0, 2.5, 5.0, 7.5, 10.0, 12.5, 15.0, 20.0, 25.0, 30.0
-            ]
+                0.001,
+                0.005,
+                0.01,
+                0.02,
+                0.04,
+                0.06,
+                0.08,
+                0.1,
+                0.25,
+                0.5,
+                0.75,
+                1.0,
+                2.5,
+                5.0,
+                7.5,
+                10.0,
+                12.5,
+                15.0,
+                20.0,
+                25.0,
+                30.0,
+            ],
         )
         self._histogram_prompt_eval_time = Histogram(
             name="llama_cpp_python:p_eval_t_seconds",
             documentation="Histogram of prompt evaluation time in seconds",
             labelnames=self.labels,
             buckets=[
-                0.1, 0.25, 0.5, 0.75, 1.0, 2.5, 5.0, 7.5, 10.0, 12.5, 15.0,
-                20.0, 25.0, 30.0, 40.0, 50.0, 60.0
-            ]
+                0.1,
+                0.25,
+                0.5,
+                0.75,
+                1.0,
+                2.5,
+                5.0,
+                7.5,
+                10.0,
+                12.5,
+                15.0,
+                20.0,
+                25.0,
+                30.0,
+                40.0,
+                50.0,
+                60.0,
+            ],
         )
         self._histogram_completion_eval_time = Histogram(
             name="llama_cpp_python:c_eval_t_seconds",
             documentation="Histogram of completion evaluation time in seconds",
             labelnames=self.labels,
             buckets=[
-                0.1, 0.25, 0.5, 0.75, 1.0, 2.5, 5.0, 7.5, 10.0, 12.5, 15.0,
-                20.0, 25.0, 30.0, 40.0, 50.0, 60.0
-            ]
+                0.1,
+                0.25,
+                0.5,
+                0.75,
+                1.0,
+                2.5,
+                5.0,
+                7.5,
+                10.0,
+                12.5,
+                15.0,
+                20.0,
+                25.0,
+                30.0,
+                40.0,
+                50.0,
+                60.0,
+            ],
         )
         self._histogram_e2e_request_latency = Histogram(
             name="llama_cpp_python:e2e_seconds",
             documentation="Histogram of end-to-end request latency in seconds",
             labelnames=self.labels,
             buckets=[
-                0.1, 0.25, 0.5, 0.75, 1.0, 2.5, 5.0, 7.5, 10.0, 12.5, 15.0,
-                20.0, 25.0, 30.0, 40.0, 50.0, 60.0
-            ]
+                0.1,
+                0.25,
+                0.5,
+                0.75,
+                1.0,
+                2.5,
+                5.0,
+                7.5,
+                10.0,
+                12.5,
+                15.0,
+                20.0,
+                25.0,
+                30.0,
+                40.0,
+                50.0,
+                60.0,
+            ],
         )
         # Prefill and generation tokens
         self._histogram_prefill_tokens = Histogram(
@@ -115,98 +242,146 @@ class MetricsExporter:
             documentation="Histogram of number of prefill tokens processed",
             labelnames=self.labels,
             buckets=[
-                1, 10, 25, 50, 100, 250, 500, 750, 1000, 1500, 2000, 2500, 3000,
-                3500, 4000, 4500, 5000
-            ]
+                1,
+                10,
+                25,
+                50,
+                100,
+                250,
+                500,
+                750,
+                1000,
+                1500,
+                2000,
+                2500,
+                3000,
+                3500,
+                4000,
+                4500,
+                5000,
+            ],
         )
         self._histogram_generation_tokens = Histogram(
             name="llama_cpp_python:completion_tokens_total",
             documentation="Histogram of number of generation tokens processed",
             labelnames=self.labels,
             buckets=[
-                1, 10, 25, 50, 100, 250, 500, 750, 1000, 1500, 2000, 2500, 3000,
-                3500, 4000, 4500, 5000
-            ]
+                1,
+                10,
+                25,
+                50,
+                100,
+                250,
+                500,
+                750,
+                1000,
+                1500,
+                2000,
+                2500,
+                3000,
+                3500,
+                4000,
+                4500,
+                5000,
+            ],
         )
         # Current throughput
         self._gauge_prompt_eval_throughput = Gauge(
             name="llama_cpp_python:prompt_eval_throughput",
             documentation="Current throughput of the prompt evaluation process (in tokens/second)",
-            labelnames=self.labels
+            labelnames=self.labels,
         )
         self._gauge_completion_eval_throughput = Gauge(
             name="llama_cpp_python:completion_eval_throughput",
             documentation="Current throughput of the completion evaluation process (in tokens/second)",
-            labelnames=self.labels
+            labelnames=self.labels,
         )
         self._gauge_sample_throughput = Gauge(
             name="llama_cpp_python:sample_throughput",
             documentation="Current throughput of the token sampling process (in tokens/second)",
-            labelnames=self.labels
+            labelnames=self.labels,
         )
         # System info
         self._gauge_state_size = Gauge(
             name="llama_cpp_python:state_size",
             documentation="Current state size in bytes of various components such as rng (random number generator), logits, embedding, and kv_cache (key-value cache)",
-            labelnames=self.labels
+            labelnames=self.labels,
         )
         self._gauge_cpu_utilization = Gauge(
             name="llama_cpp_python:cpu_utilization",
             documentation="Current CPU utilization",
-            labelnames=self.labels
+            labelnames=self.labels,
         )
         self._gauge_cpu_ram_usage_by_pid = Gauge(
             name="llama_cpp_python:cpu_memory_usage_by_pid",
             documentation="Current CPU memory usage during the request",
-            labelnames=self.labels
+            labelnames=self.labels,
         )
         self._gauge_gpu_utilization = Gauge(
             name="llama_cpp_python:gpu_utilization",
             documentation="Current GPU utilization",
-            labelnames=self.labels
+            labelnames=self.labels,
         )
         self._gauge_gpu_memory_usage = Gauge(
             name="llama_cpp_python:gpu_memory_usage",
             documentation="Current GPU memory usage",
-            labelnames=self.labels
+            labelnames=self.labels,
         )
         self._gauge_gpu_memory_free = Gauge(
             name="llama_cpp_python:gpu_memory_free",
             documentation="Current free GPU memory",
-            labelnames=self.labels
+            labelnames=self.labels,
         )
         self._gauge_gpu_memory_usage_by_pid = Gauge(
             name="llama_cpp_python:gpu_memory_usage_by_pid",
             documentation="Current GPU memory usage during the request",
-            labelnames=self.labels
+            labelnames=self.labels,
         )
         self._gauge_kv_cache_usage_ratio = Gauge(
             name="llama_cpp_python:kv_cache_usage_ratio",
             documentation="KV-cache usage. 1 means 100 percent usage",
-            labelnames=self.labels
+            labelnames=self.labels,
         )
-        self._info = Info(
-            name="llama_cpp_python:info",
-            documentation="Server metadata"
+        self._gauge_running_tasks = Gauge(
+            name="llama_cpp_python:running_tasks",
+            documentation="Number of running tasks in the task queue",
+            labelnames=self.labels,
         )
 
-    def log_metrics(self, metrics: Metrics, labels: Dict[str, str]):
+        # Server metadata
+        self._info = Info(name="llama_cpp_python:info", documentation="Server metadata")
+
+    def log_request_metrics(self, metrics: RequestMetrics, labels: Dict[str, str]):
         """
         Log the metrics using the Prometheus client.
         """
         self._histogram_load_time.labels(**labels).observe(metrics.load_time)
         self._histogram_sample_time.labels(**labels).observe(metrics.sample_time)
         if metrics.time_to_first_token:
-            self._histogram_time_to_first_token.labels(**labels).observe(metrics.time_to_first_token)
+            self._histogram_time_to_first_token.labels(**labels).observe(
+                metrics.time_to_first_token
+            )
         for _tpot in metrics.time_per_output_token:
             self._histogram_time_per_output_token.labels(**labels).observe(_tpot)
-        self._histogram_prompt_eval_time.labels(**labels).observe(metrics.prompt_eval_time)
-        self._histogram_completion_eval_time.labels(**labels).observe(metrics.completion_eval_time)
-        self._histogram_e2e_request_latency.labels(**labels).observe(metrics.end_to_end_latency)
+        self._histogram_prompt_eval_time.labels(**labels).observe(
+            metrics.prompt_eval_time
+        )
+        self._histogram_completion_eval_time.labels(**labels).observe(
+            metrics.completion_eval_time
+        )
+        self._histogram_e2e_request_latency.labels(**labels).observe(
+            metrics.end_to_end_latency
+        )
         self._histogram_prefill_tokens.labels(**labels).observe(metrics.prefill_tokens)
-        self._histogram_generation_tokens.labels(**labels).observe(metrics.generation_tokens)
-        self._gauge_prompt_eval_throughput.labels(**labels).set(metrics.prompt_eval_throughput)
-        self._gauge_completion_eval_throughput.labels(**labels).set(metrics.completion_eval_throughput)
+        self._histogram_generation_tokens.labels(**labels).observe(
+            metrics.generation_tokens
+        )
+        self._gauge_prompt_eval_throughput.labels(**labels).set(
+            metrics.prompt_eval_throughput
+        )
+        self._gauge_completion_eval_throughput.labels(**labels).set(
+            metrics.completion_eval_throughput
+        )
         self._gauge_sample_throughput.labels(**labels).set(metrics.sample_throughput)
         self._gauge_cpu_utilization.labels(**labels).set(metrics.cpu_utilization)
         self._gauge_cpu_ram_usage_by_pid.labels(**labels).set(metrics.cpu_ram_pid)
@@ -215,5 +390,13 @@ class MetricsExporter:
         self._gauge_gpu_memory_free.labels(**labels).set(metrics.gpu_ram_free)
         self._gauge_gpu_memory_usage_by_pid.labels(**labels).set(metrics.gpu_ram_pid)
         self._gauge_state_size.labels(**labels).set(metrics.state_size)
-        self._gauge_kv_cache_usage_ratio.labels(**labels).set(metrics.kv_cache_usage_ratio)
+        self._gauge_kv_cache_usage_ratio.labels(**labels).set(
+            metrics.kv_cache_usage_ratio
+        )
         self._info.info(metrics.system_info)
+
+    def log_queue_metrics(self, metrics: QueueMetrics, labels: Dict[str, str]):
+        """
+        Log the metrics for the task queue.
+        """
+        self._gauge_running_tasks.labels(**labels).set(metrics.running_tasks_count)

--- a/llama_cpp/server/types.py
+++ b/llama_cpp/server/types.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import List, Optional, Union, Dict
+from typing import List, Optional, Union, Dict, Any
 from typing_extensions import TypedDict, Literal
 
 from pydantic import BaseModel, Field
@@ -317,3 +317,7 @@ class DetokenizeInputResponse(BaseModel):
     model_config = {
         "json_schema_extra": {"example": {"text": "How many tokens in this query?"}}
     }
+
+class HealthMetrics(BaseModel):
+    model_config = {"arbitrary_types_allowed": True}
+    task_queue_status: Dict[str, Any]


### PR DESCRIPTION
Closes ZenHubHQ/devops#2258. Exposes a `/health/` endpoint with the following output:

```
{
  "status": "OK",
  "task_queue_status": {
    "running_tasks_count": 4,
    "running_tasks": {
      "Task-1": "\u003Ccoroutine object Server.serve at 0x1188073d0\u003E",
      "Task-19651938": "\u003Ccoroutine object monitor_task_queue at 0x11ff75030\u003E",
      "Task-2": "\u003Ccoroutine object LifespanOn.main at 0x11ff50840\u003E",
      "Task-19651939": "\u003Ccoroutine object RequestResponseCycle.run_asgi at 0x11ff51140\u003E"
    }
  }
}
```

Also performs basic code linting across all the modified files.

